### PR TITLE
Use lazy loading import for i18n files

### DIFF
--- a/angular-lib/src/angular/modules.ts
+++ b/angular-lib/src/angular/modules.ts
@@ -1,4 +1,4 @@
 import { MaterialModule } from './modules/material.module';
-import { getTranslateModule, LazyTranslateLoader } from './modules/translate.module';
+import { getTranslateModule } from './modules/translate.module';
 
-export { MaterialModule, getTranslateModule, LazyTranslateLoader };
+export { MaterialModule, getTranslateModule };

--- a/angular-lib/src/angular/modules/translate.module.ts
+++ b/angular-lib/src/angular/modules/translate.module.ts
@@ -4,7 +4,7 @@ import { catchError } from 'rxjs/operators'
 
 export class LazyTranslateLoader implements TranslateLoader {
     getTranslation(lang: string): Observable<any> {
-      return from(import(`../../../../.ng/src/assets/i18n/${lang}.json`)).pipe(catchError(err=>of({})));
+      return from(import(`../../../../.ng/src/i18n/${lang}.json`)).pipe(catchError(err=>of({})));
     }
   }
 

--- a/cli/scripts/extract-labels.js
+++ b/cli/scripts/extract-labels.js
@@ -7,7 +7,7 @@ const {cwd, appBaseDir, workNg, work} = require("../lib/dirs");
 syncNgDir()
   .then(() => extractLabels([
       `--input`, `${work}/src`, 
-      `--output`, `${work}/src/assets/i18n/labels.json`,
+      `--output`, `${work}/src/i18n/labels.json`,
       `--clean`,`--sort`, `--format`, `namespaced-json`
     ]))
     .catch(error => {


### PR DESCRIPTION
Intended to resolve the following issues:
* 404 errors for non-existent languages/translations from TranslateHttpLoader
* JSON files are cached after new build and translations are not available

Solution based on https://github.com/ngx-translate/http-loader/issues/25#issuecomment-514056865