### PR TITLE
Change names of almaBack and almaMainPage APIs

### DIFF
--- a/angular-lib/src/angular/services/cloudapp-events.service.ts
+++ b/angular-lib/src/angular/services/cloudapp-events.service.ts
@@ -53,11 +53,11 @@ export class CloudAppEventsService implements OnDestroy {
     return this._getObservable(CloudAppOutgoingEvents.reloadPage);
   }
 
-  almaBack(): Observable<RefreshPageResponse> {
+  back(): Observable<RefreshPageResponse> {
     return this._getObservable(CloudAppOutgoingEvents.almaBack);
   }
   
-  almaMainPage(): Observable<RefreshPageResponse> {
+  home(): Observable<RefreshPageResponse> {
     return this._getObservable(CloudAppOutgoingEvents.almaMainPage);
   }
 


### PR DESCRIPTION
@ori229 - I think I prefer the more simple names `back` and `home`. What do you think?