### PR TITLE
Add CloudAppPageService

### DIFF
--- a/angular-lib/src/angular/services.ts
+++ b/angular-lib/src/angular/services.ts
@@ -3,6 +3,7 @@ import { CloudAppRestService } from './services/cloudapp-rest.service';
 import { CloudAppStoreService } from './services/cloudapp-store.service';
 import { CloudAppSettingsService } from './services/cloudapp-settings.service';
 import { CloudAppConfigService } from './services/cloudapp-config.service';
+import { CloudAppPageService } from './services/cloudapp-page.service';
 import { InitService } from './services/init.service';
 
 export {
@@ -11,5 +12,6 @@ export {
     CloudAppStoreService,
     CloudAppSettingsService,
     CloudAppConfigService,
+    CloudAppPageService,
     InitService
 };

--- a/angular-lib/src/angular/services/cloudapp-page.service.ts
+++ b/angular-lib/src/angular/services/cloudapp-page.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { fromEventPattern, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { CloudAppEventsService } from './cloudapp-events.service';
+import {
+  Entity,
+  PageInfo,
+  RefreshPageResponse,
+} from '../../lib/public-interfaces';
+
+/**
+ * Wraps the CloudAppEventService to provide a simplified interface for
+ * interacting with the currently-loaded Alma page.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class CloudAppPageService {
+  constructor(private eventsService: CloudAppEventsService) {}
+
+  /**
+   * Never completes; be sure to unsubscribe or use an async pipe.
+   */
+  readonly entities$: Observable<Entity[]> = fromEventPattern<PageInfo>(
+    (handler) => this.eventsService.onPageLoad(handler),
+    (_, subscription) => subscription.unsubscribe()
+  ).pipe(
+    map((pageInfo) => pageInfo.entities ?? [])
+  );
+
+  refresh(): Observable<RefreshPageResponse> {
+    return this.eventsService.refreshPage();
+  }
+
+  back(): Observable<RefreshPageResponse> {
+    return this.eventsService.back();
+  }
+
+  home(): Observable<RefreshPageResponse> {
+    return this.eventsService.home();
+  }
+}


### PR DESCRIPTION
Please feel free to reject this PR if you don't think it will be useful to other SDK users...

Whenever I use the SDK, I find myself wanting to avoid the `onPageLoad` event handler to listen for page entity changes, so I wrap the event handler in an observable using [fromEventPattern](https://rxjs-dev.firebaseapp.com/api/index/function/fromEventPattern). The primary advantage of doing this is that you can use an [async pipe](https://angular.io/api/common/AsyncPipe) to watch for new page entities, which means that you do not need to worry about explicitly subscribing and unsubscribing. Using async pipes also means that you can use an `OnPush` [ChangeDetectionStrategy](https://angular.io/api/core/ChangeDetectionStrategy) in your component. 

## Example Usage 
Within an app that modifies item records, you might have something like this in a component: 
```typescript
@Component({
  selector: 'app-main',
  templateUrl: './main.component.html',
  styleUrls: ['./main.component.scss'],
  changeDetection: ChangeDetectionStrategy.OnPush,
})
export class MainComponent {
  constructor(private almaPage: CloudAppPageService, private restService: CloudAppRestService)
  item$: Observable<Item> = this.almaPage.entities$.pipe(
    switchMap((entities) => {
      if (entities.length === 1 && entities[0].type === EntityType.ITEM) {
        return this.restService.call<Item>(entities[0].link);
    })
  );
}
```
And the component template might contain something like this: 
```html
<section *ngIf="item$ | async as item">
...
</section>
```
