### PR TITLE
Add entities Observable for onPageLoad

### DIFF
--- a/angular-lib/src/angular/services/cloudapp-events.service.ts
+++ b/angular-lib/src/angular/services/cloudapp-events.service.ts
@@ -1,10 +1,10 @@
 import { isEqual } from 'lodash';
 import { takeUntil, concatMap, map } from 'rxjs/operators';
 import { Injectable, OnDestroy } from '@angular/core';
-import { Subject, Subscription, BehaviorSubject, Observable, defer, throwError, of } from 'rxjs';
+import { Subject, Subscription, BehaviorSubject, Observable, defer, throwError, of, fromEventPattern } from 'rxjs';
 
 import { MessageEventHandler } from '../../lib/messages/interfaces';
-import { PageInfo, InitData, RefreshPageResponse } from '../../lib/public-interfaces';
+import { PageInfo, InitData, RefreshPageResponse, Entity } from '../../lib/public-interfaces';
 import { CloudAppOutgoingEvents } from '../../lib/events/outgoing-events';
 import { CloudAppIncomingEvents } from '../../lib/events/incoming-events';
 import { EventServiceLogger as logger } from './service-loggers';
@@ -24,6 +24,13 @@ export class CloudAppEventsService implements OnDestroy {
     logger.log('Initializing CloudAppEventsService');
     this._init();
   }
+
+  readonly entities$: Observable<Entity[]> = fromEventPattern<PageInfo>(
+    (handler) => this.onPageLoad(handler),
+    (_, subscription) => subscription.unsubscribe()
+  ).pipe(
+    map((pageInfo) => pageInfo.entities ?? [])
+  );
 
   getInitData(): Observable<InitData> {
     return this._getObservable(CloudAppOutgoingEvents.getInitData).pipe(


### PR DESCRIPTION
Following up on #24 , added the `entities$` observable to the `CloudAppEventsService`. 

Usage:
```
<section *ngIf="eventsService.entities$ | async as entities">
  <p *ngFor="let entity of entities">{{entity.description}}</p>
</section>
```

Or:
*component.ts*
```
  items$: Observable<Item[]> = this.eventsService.entities$
  .pipe(
    switchMap((entities) => {
      const items = entities.filter(e=>e.type==EntityType.ITEM);
      return iif(()=>items.length>0,
        forkJoin(items.map(e=>this.restService.call<Item>(e.link))),
        of(null)
      )
    })
  );
```
*component.html*
```
<section *ngIf="items$ | async as items">
  <p *ngFor="let item of items">Barcode-{{item.item_data.barcode}}</p>
</section>
```